### PR TITLE
write fields valid at the same times but not sharing the same basetime in NetCDF writefield

### DIFF
--- a/epygram/formats/netCDF.py
+++ b/epygram/formats/netCDF.py
@@ -1091,6 +1091,11 @@ class netCDF(FileResource):
                 self._variables[tgrid][:] = datetimes
                 self._variables[tgrid].units = ' '.join(['seconds', 'since', datetime0])
             else:
+                units = self._variables[tgrid].units.split(sep=' ')
+                units_base = datetime.datetime.strptime(' '.join(units[2:4]), '%Y-%m-%d %H:%M:%S')
+                if field.validity[0].getbasis() != units_base:
+                    basediff = field.validity[0].getbasis() - units_base
+                    datetimes = [dt + int(basediff.total_seconds()) for dt in datetimes]
                 assert (self._variables[tgrid][:] == datetimes).all(), \
                     ' '.join(['variable', tgrid, 'mismatch.'])
 


### PR DESCRIPTION
Add support of different field validity bases in writefield in NetCDF, provided that the dates match.

rebase datetimes of the new field if the validity basis of the new field to write differs from the units basetime of the existing time variable before comparing the two lists of time steps.

This allows to combine fields in a single file that are valid at the same time but come from different sources. For example forecasts from different systems that don't have the same analysis time.