### PR TITLE
support slice type object as value of the only keyword argument of the NetCDF readfield method

### DIFF
--- a/epygram/formats/netCDF.py
+++ b/epygram/formats/netCDF.py
@@ -893,7 +893,12 @@ class netCDF(FileResource):
                 buffdata = variable
                 for k, i in only.items():
                     d = variable.dimensions.index(k)
-                    buffdata = util.restrain_to_index_i_of_dim_d(buffdata, i, d, n=n)
+                    if isinstance(i, slice):
+                        ibuff = [util.restrain_to_index_i_of_dim_d(buffdata, j, d, n=n) for j in
+                                 range(i.start, i.stop, i.step)]
+                        buffdata = numpy.concatenate(ibuff, axis=d)
+                    else:
+                        buffdata = util.restrain_to_index_i_of_dim_d(buffdata, i, d, n=n)
             else:
                 buffdata = variable[...]
             # check there is no leftover unknown dimension


### PR DESCRIPTION
add support of slice type object as value of the only keyword argument of the NetCDF readfield method.

This commit solves an issue that occurs when passing a slice to the "only" keyword argument of the NetCDF readfield method. The error occurs because the restrain_to_index_i_of_dim_d method accepts only a single index i. 
The proposed solution consists of looping over the the indices in the slice creating a list of data buffers and then concatenating them along dimension d.