### PR TITLE
Extend epy_spectrum.py to global non-stretched Gaussian grids

### DIFF
--- a/docs/source/apptools.rst
+++ b/docs/source/apptools.rst
@@ -22,7 +22,7 @@ Currently available:
 - ``epy_cartoplot.py``: plot horizontal 2D fields using cartopy package
 - ``epy_hist.py``: compute and plot a histogram of fields values
 - ``epy_point.py``: extract the value of fields on a given location
-- ``epy_spectrum.py``: compute and plot the DCT spectrum of a field
+- ``epy_spectrum.py``: compute and plot the energy spectrum of a field,
 - ``fa_sp2gp.py``: convert to gridpoint the spectral fields of a FA file
 - ``domain_maker.py``: interactive construction and display of a new LAM domain
 - ``ddhlfa_plot.py``: basic plots of LFA-formatted outputs from DDH

--- a/docs/source/library/spectra.rst
+++ b/docs/source/library/spectra.rst
@@ -20,6 +20,7 @@ Functions
 
 .. autofunction:: read_Spectrum
 .. autofunction:: dctspectrum
+.. autofunction:: global_spectrum
 .. autofunction:: sort
 .. autofunction:: plotspectra
 

--- a/src/epygram/fields/H2DField.py
+++ b/src/epygram/fields/H2DField.py
@@ -15,7 +15,7 @@ from numpy import unravel_index
 import footprints
 
 from epygram import epygramError
-from epygram.geometries import Geometry, GaussGeometry
+from epygram.geometries import Geometry
 from . import gimme_one_point
 from .D3Field import D3Field
 from .PointField import PointField
@@ -145,33 +145,6 @@ class H2DField(D3Field):
         """
         i, j = self.index_of_minmax_value(min_or_max)
         return self.geometry.ij2ll(i, j)
-
-    def get_variance_spectrum(self):
-        """
-        Return variance spectrum of a spectral field with GaussGeometry.
-        """
-        assert self.spectral
-        assert isinstance(self.geometry, GaussGeometry)
-        assert self.spectral_geometry.truncation["shape"] == "triangular"
-        nsmax = self.spectral_geometry.truncation["max"]
-        variances = numpy.zeros(nsmax + 1)
-        jdata = 0
-        # Loop on zonal wavenumbers m
-        for m in range(nsmax + 1):
-            # Loop on total wavenumber n
-            for n in range(m, nsmax + 1):
-                squaredmodule = self._data[0, 0, jdata] ** 2 + self._data[0, 0, jdata+1] ** 2
-                if m == 0:
-                    variances[n] += squaredmodule
-                    # Check that coefficient (m, n) == (0, n) is its own complex conjugate,
-                    # i.e. it has zero imaginary part
-                    assert self._data[0, 0, jdata+1] == 0
-                else:
-                    # Coefficient (-m, n) is the complex conjugate of (m, n).
-                    # It is not stored so (m, n) should be counted twice.
-                    variances[n] += 2 * squaredmodule
-                jdata += 2
-        return variances
 
 ###################
 # PRE-APPLICATIVE #

--- a/src/epygram/fields/H2DField.py
+++ b/src/epygram/fields/H2DField.py
@@ -15,7 +15,7 @@ from numpy import unravel_index
 import footprints
 
 from epygram import epygramError
-from epygram.geometries import Geometry
+from epygram.geometries import Geometry, GaussGeometry
 from . import gimme_one_point
 from .D3Field import D3Field
 from .PointField import PointField
@@ -145,6 +145,33 @@ class H2DField(D3Field):
         """
         i, j = self.index_of_minmax_value(min_or_max)
         return self.geometry.ij2ll(i, j)
+
+    def get_variance_spectrum(self):
+        """
+        Return variance spectrum of a spectral field with GaussGeometry.
+        """
+        assert self.spectral
+        assert isinstance(self.geometry, GaussGeometry)
+        assert self.spectral_geometry.truncation["shape"] == "triangular"
+        nsmax = self.spectral_geometry.truncation["max"]
+        variances = numpy.zeros(nsmax + 1)
+        jdata = 0
+        # Loop on zonal wavenumbers m
+        for m in range(nsmax + 1):
+            # Loop on total wavenumber n
+            for n in range(m, nsmax + 1):
+                squaredmodule = self._data[0, 0, jdata] ** 2 + self._data[0, 0, jdata+1] ** 2
+                if m == 0:
+                    variances[n] += squaredmodule
+                    # Check that coefficient (m, n) == (0, n) is its own complex conjugate,
+                    # i.e. it has zero imaginary part
+                    assert self._data[0, 0, jdata+1] == 0
+                else:
+                    # Coefficient (-m, n) is the complex conjugate of (m, n).
+                    # It is not stored so (m, n) should be counted twice.
+                    variances[n] += 2 * squaredmodule
+                jdata += 2
+        return variances
 
 ###################
 # PRE-APPLICATIVE #


### PR DESCRIPTION
## Description

This PR proposes an extension of epy_spectrum.py to global non-stretched Gaussian grids. The spectral coefficients are just read from the field data, and aggregated by total wavenumber, similarly to what is done in the `SPNORM` routines of arpifs. 

This extension relies on the addition of a new function `epygram.spectra.global_variances(field: H2DField)`, for use outside of epy_spectrum.py. 

A new function `prepare_field_and_get_spectrum` has been introduced in epy_plot.py to limit duplicate code.

## Impact

This should have no impact on existing use. The code has been refactored to have different behaviour depending on the geometry, the current behaviour for LAM fields is unchanged.