### PR TITLE
Create spectral geometry if required in epy_spectrum.py

### DIFF
--- a/bin/epy_spectrum.py
+++ b/bin/epy_spectrum.py
@@ -124,9 +124,9 @@ def main(filename,
                 subzone = None
             spectral_geometry = get_spectral_geometry(field, resource, verbose=verbose)
             spectra.append(field.spectrum(f,
-                           spectral_geometry=spectral_geometry,
-                           subzone=subzone,
-                           verbose=verbose))
+                                          spectral_geometry=spectral_geometry,
+                                          subzone=subzone,
+                                          verbose=verbose))
             if not noplot:
                 # plot
                 if legend is not None:


### PR DESCRIPTION
## Description 

When plotting the spectrum of a grid-point field on a Gaussian grid using epy_spectrum.py, a `SpectralGeometry` object is required. By default, the code relies on the `spectral_geometry` attribute of the resource, which may not always exist, for example for some GRIB files. 

To fix this, I add a short utility function that returns the spectral geometry of the given field by default, of the resource if the field has no spectral geometry.  If neither the field nor the resource have a spectral geometry, and if the grid is Gaussian, a spectral geometry object is built assuming a linear truncation with triangular shape. 

If there ever is a need to use another truncation (e.g., cubic), I could add this as a new application parameter, but I do not think it is required for now. 

## Impact

No numerical impact expected