### PR TITLE
bugfix in ddhlfa_plot

### DIFF
--- a/src/epygram/cli/ddhlfa_plot.py
+++ b/src/epygram/cli/ddhlfa_plot.py
@@ -138,7 +138,7 @@ def get_args():
 
     # 2.2 list of fields to be processed
     if args.field is not None:
-        fieldseed = args.field
+        args.fieldseed = args.field
     elif args.listoffields is not None:
         listfile = epygram.containers.File(filename=args.listoffields)
         with open(listfile.abspath, 'r') as l:


### PR DESCRIPTION
Just added "args." in the call of fieldseed as the original version was causing crashes:
Traceback (most recent call last):
  File "/.../bin/epygram", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/.../lib/python3.12/site-packages/epygram/cli/__init__.py", line 28, in main
    module.main()
  File "/.../lib/python3.12/site-packages/epygram/cli/ddhlfa_plot.py", line 33, in main
    args.fieldseed,
    ^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'fieldseed'