### PR TITLE
Do not enforce linear grid in H2DField.spectrum()

### DIFF
--- a/src/epygram/fields/H2DField.py
+++ b/src/epygram/fields/H2DField.py
@@ -8,7 +8,7 @@ Contains the class that handle a Horizontal 2D field.
 """
 
 import numpy
-from numpy import unravel_index
+from numpy import pi, unravel_index
 
 import footprints
 
@@ -168,8 +168,8 @@ class H2DField(D3Field):
                 assert spectral_geometry, "Need spectral geometry to convert field in gp space!"
                 self.gp2sp(spectral_geometry)
             variances = esp.global_spectrum(self)
-            nlat = self.geometry.dimensions["lat_number"]
-            resolution = self.geometry.zonal_resolution_j(nlat // 2) / 1000
+            earth_circumference = 2 * pi * self.geometry.geoid["a"] / 1000
+            resolution = earth_circumference / (variances.size * 2)
             spectrum =  esp.Spectrum(variances[1:],
                                      name=str(fname),
                                      resolution=resolution,


### PR DESCRIPTION
## Description

This PR changes the way the spectrum resolution is computed in `H2DField.spectrum()`.

It used to be computed from the zonal resolution of the parallel closest to the Equator. 

It is now computed directly from the geoid circumference, which is more accurate (although the difference is minor, about 2e-5).
It is also computed from the number of wavenumbers, which removes the implied assumption that the spectral truncation is linear.

## Addressed issues
Fixes #55 