### PR TITLE
add FA limits setting from config (req falfilfa4py 1.0.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "bronx",
     "eccodes==2.38.0",  # ! consistency with falfilfa4py !
     "ectrans4py",
-    "falfilfa4py==1.0.5",  # ! consistency with eccodes !
+    "falfilfa4py==1.0.6",  # ! consistency with eccodes !
     "footprints",
     "netCDF4",
     "numpy",

--- a/src/epygram/__init__.py
+++ b/src/epygram/__init__.py
@@ -130,7 +130,9 @@ def init_env(omp_num_threads=1,
              mute_FA4py=None,
              unlimited_stack=True,
              ensure_consistent_GRIB_paths=False,
-             ignore_gribenv_paths=False):
+             ignore_gribenv_paths=False,
+             fa_limits=config.FA_limits,
+             ):
     """
     A function to modify execution environment (to be called early in
     execution).
@@ -145,6 +147,7 @@ def init_env(omp_num_threads=1,
     :param ignore_gribenv_paths: ignore predefined values of the variables
         GRIB_SAMPLES_PATH and GRIB_DEFINITION_PATH
         (or equivalent ECCODES variables)
+    :param fa_limits: FA limits
     """
     # 1. falfilfa4py library
     # FA & LFI need some special environment setting
@@ -154,7 +157,8 @@ def init_env(omp_num_threads=1,
             mute_FA4py = config.FA_mute_FA4py
         falfilfa4py.init_env(omp_num_threads=omp_num_threads, no_mpi=no_mpi,
                              lfi_C=lfi_C, mute_FA4py=mute_FA4py,
-                             unlimited_stack=unlimited_stack)
+                             unlimited_stack=unlimited_stack,
+                             fa_limits=fa_limits)
         if ensure_consistent_GRIB_paths: #CLEANME:DEPRECATED:
             from epygram.extra import griberies
             eccodes_libpath = falfilfa4py.get_dynamic_eccodes_lib_path_from_FA()

--- a/src/epygram/config.py
+++ b/src/epygram/config.py
@@ -93,6 +93,13 @@ FA_allow_MOCAGE_multivalidities = False
 FA_max_encoding = 30
 #: Mute messages from FAIPAR in FA4py
 FA_mute_FA4py = False
+#: FA limits
+FA_limits = {'JPXTRO':4000,  # Maximum truncation
+             'JPXLAT':4000,  # Maximum number of latitudes
+             'JPXNIV':200,  # Maximum number of levels
+             'JPNXFA':20,  # Maximum number of open files
+             'JPNXCA':20, # Maximum number of headers
+             }
 
 #: LFA maximum number of fields
 LFA_max_num_fields = 1000


### PR DESCRIPTION
To be able to deal with higher truncation and bigger grids in falfilfa4py without recompiling.
Requires ACCORD-NWP/FALFILFA#26