### PR TITLE
Fix vortex version check in `usevortex` module

### DIFF
--- a/src/epygram/extra/usevortex.py
+++ b/src/epygram/extra/usevortex.py
@@ -22,9 +22,6 @@ from bronx.stdtypes.date import daterange
 import taylorism
 
 import vortex
-from vortex import toolbox
-import common  # @UnusedImport : for footprints to load classes
-import olive  # @UnusedImport : for footprints to load classes
 
 assert vortex.__version__ < '2.0.0', "Module 'usevortex' is not compatible with vortex-2"
 logging.warning(
@@ -32,6 +29,10 @@ logging.warning(
               "For more information, see http://confluence.meteo.fr/display/GMAP/Epygram"]
              )
     )
+
+from vortex import toolbox
+import common  # @UnusedImport : for footprints to load classes
+import olive  # @UnusedImport : for footprints to load classes
 
 
 def list_vortex_geometries():

--- a/src/epygram/extra/usevortex.py
+++ b/src/epygram/extra/usevortex.py
@@ -23,7 +23,13 @@ import taylorism
 
 import vortex
 
-assert vortex.__version__ < '2.0.0', "Module 'usevortex' is not compatible with vortex-2"
+incompat_msg = (
+    "Module 'usevortex' is not compatible with vortex>=2. "
+    "For information on performing operations previously provided "
+    "by the 'usevortex' module, see "
+    "http://confluence.meteo.fr/display/GMAP/Vortex+2+HOWTO."
+)
+assert vortex.__version__ < '2.0.0', incompat_msg
 logging.warning(
     " ".join(["Module 'usevortex' is deprecated and will be removed in epygram-2.2.0.",
               "For more information, see http://confluence.meteo.fr/display/GMAP/Epygram"]


### PR DESCRIPTION
Currently the `usevortex` module features vortex<2 specific imports (`import common`) _before_ the vortex version is checked. This means that a user using vortex>= will first hist a `ImportError` before even reaching the version check.

This moves the vortex<2 specific imports _after_ the version check.

This also slightly change the message about `usevortex` being incompatible with vortex>=2 by adding a link to the vortex HOWTO.