### PR TITLE
Fix diffmode arg in histogram

### DIFF
--- a/src/epygram/cli/histogram.py
+++ b/src/epygram/cli/histogram.py
@@ -305,7 +305,7 @@ def get_args():
     else:
         args.refname = args.refname
         args.diffonly = False
-    args.diffmode = refname is not None
+    args.diffmode = args.refname is not None
     if args.zone in ('C', 'CI'):
         args.subzone = args.zone
     elif args.zone == 'CIE':


### PR DESCRIPTION
With epy_histogram (v2.0.7) I was getting the following on Atos:

```
$ epy_histogram -f "CLSTEMPERATURE" ICMSHDEOD+0003h00m00s -o "X"
Traceback (most recent call last):
  File "/home/dujf/.local/bin/epy_histogram", line 8, in <module>
    sys.exit(main())
  File "/home/dujf/.local/lib/python3.10/site-packages/epygram/cli/histogram.py", line 33, in main
    args = get_args()
  File "/home/dujf/.local/lib/python3.10/site-packages/epygram/cli/histogram.py", line 308, in get_args
    args.diffmode = refname is not None
NameError: name 'refname' is not defined
```