### PR TITLE
Remove numpy deprecation warnings

### DIFF
--- a/src/epygram/formats/LFI.py
+++ b/src/epygram/formats/LFI.py
@@ -1231,6 +1231,8 @@ class LFI(FileResource):
         def k(latin2):
             latin1 = lat0
             m1 = math.cos(math.radians(latin1))
+            if isinstance(latin2, numpy.ndarray) and len(latin2) == 1:
+                latin2 = latin2[0]
             m2 = math.cos(math.radians(latin2))
             t1 = math.tan(math.pi / 4. - math.radians(latin1) / 2.)
             t2 = math.tan(math.pi / 4. - math.radians(latin2) / 2.)

--- a/src/epygram/formats/netCDFMNH.py
+++ b/src/epygram/formats/netCDFMNH.py
@@ -913,6 +913,8 @@ class netCDFMNH(FileResource):
         def k(latin2):
             latin1 = lat0
             m1 = math.cos(math.radians(latin1))
+            if isinstance(latin2, numpy.ndarray) and len(latin2) == 1:
+                latin2 = latin2[0]
             m2 = math.cos(math.radians(latin2))
             t1 = math.tan(math.pi / 4. - math.radians(latin1) / 2.)
             t2 = math.tan(math.pi / 4. - math.radians(latin2) / 2.)

--- a/tests/test_combinationsextractions.py
+++ b/tests/test_combinationsextractions.py
@@ -396,10 +396,9 @@ class TestMisc(TestCase):
         for field in fields[1:]:
             self.assertEqual(field.geometry, fields[0].geometry)
 
-    # FIXME: AM-16/05/2024 : hard crash with this test
-    #def test_V1D_variousways(self):
-    #    # Test Subdomain, CombineLevels and MultiValidities for V1D
-    #    self._test__variousways('V1D')
+    def test_V1D_variousways(self):
+        # Test Subdomain, CombineLevels and MultiValidities for V1D
+        self._test__variousways('V1D')
 
     def test_V2D_variousways(self):
         # Test Subdomain, CombineLevels and MultiValidities for V2D


### PR DESCRIPTION
The 69670 remaining warnings occuring during `make tests_full` are due to a scalar fast path used in pyproj and should automatically disapear when numpy will throw an error instead of a warning.