### PR TITLE
Add option to not include background

### DIFF
--- a/src/epygram/_plugins/with_cartopy/H2DField.py
+++ b/src/epygram/_plugins/with_cartopy/H2DField.py
@@ -560,6 +560,7 @@ def cartoplot(self,
               contourlabel=False,
               clabel_kw=None,
               # cartography
+              no_background=False,
               meridians='auto',
               parallels='auto',
               gridlines_kw=None,
@@ -721,16 +722,17 @@ def cartoplot(self,
                                                   set_global=(extent == 'global'))
     result = dict(fig=fig, ax=ax)
     # 2/ background
-    self.cartoplot_background(ax,
-                              projection,
-                              cartopy_features,
-                              natural_earth_features,
-                              meridians,
-                              parallels,
-                              gridlines_kw,
-                              epygram_departments,
-                              subzone=subzone,
-                              extent=extent)
+    if not no_background:
+        self.cartoplot_background(ax,
+                                  projection,
+                                  cartopy_features,
+                                  natural_earth_features,
+                                  meridians,
+                                  parallels,
+                                  gridlines_kw,
+                                  epygram_departments,
+                                  subzone=subzone,
+                                  extent=extent)
     # 3/ get data to plot
     if self.spectral:
         self.sp2gp()

--- a/src/epygram/_plugins/with_cartopy/H2DField.py
+++ b/src/epygram/_plugins/with_cartopy/H2DField.py
@@ -560,7 +560,7 @@ def cartoplot(self,
               contourlabel=False,
               clabel_kw=None,
               # cartography
-              no_background=False,
+              background=True,
               meridians='auto',
               parallels='auto',
               gridlines_kw=None,
@@ -643,6 +643,8 @@ def cartoplot(self,
 
     Cartography settings:
 
+    :param background: whether to plots cartography features, such as borders,
+        coastlines, meridians and parallels... Defaults to True.
     :param meridians: enable to fine-tune the choice of lines to
         plot, with either:
           - 'auto': automatic scaling to the map extents
@@ -722,7 +724,7 @@ def cartoplot(self,
                                                   set_global=(extent == 'global'))
     result = dict(fig=fig, ax=ax)
     # 2/ background
-    if not no_background:
+    if background:
         self.cartoplot_background(ax,
                                   projection,
                                   cartopy_features,


### PR DESCRIPTION
This adds the option `no_background` to `catoplot` that skips the call to `self.cartoplot_background`. This allows making figures with only the contours and without the boundaries added by cartopy.